### PR TITLE
Allow setting job options with a job_options method on the listener

### DIFF
--- a/lib/wisper/sidekiq.rb
+++ b/lib/wisper/sidekiq.rb
@@ -6,7 +6,8 @@ require 'wisper/sidekiq/version'
 module Wisper
   class SidekiqBroadcaster
     def broadcast(subscriber, publisher, event, args)
-      subscriber.delay.public_send(event, *args)
+      options = subscriber.respond_to?(:job_options) ? subscriber.job_options : {}
+      subscriber.delay(options).public_send(event, *args)
     end
 
     def self.register

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -10,4 +10,12 @@ RSpec.describe 'configuration' do
   it 'configures sidekiq as default async broadcaster' do
     expect(configuration.broadcasters[:async]).to be_an_instance_of(Wisper::SidekiqBroadcaster)
   end
+
+  it 'uses .job_options when calling delay' do
+    subscriber = double(job_options: { foo: 'bar' })
+    allow(subscriber).to receive(:delay).and_return(double(test: nil))
+
+    Wisper::SidekiqBroadcaster.new.broadcast(subscriber, double, :test, [])
+    expect(subscriber).to have_received(:delay).with({ foo: 'bar' })
+  end
 end


### PR DESCRIPTION
I'm loving this gem, but I need to be able to set various options (e.g. queue name, retry) per listener. I figured this was the most unobtrusive way to achieve this. I would have liked to be able to code something like:

``` ruby
Wisper.subscribe(MyListener, async: true, queue: 'test', retry: false)
```

but couldn't figure out how to make this work since the options aren't saved with the Registration. Might be worth changing in Wisper.

If you have ideas for a better implementation, let me know and I'll take care of it.
