### PR TITLE
Allow sidekiq_delay and not just delay

### DIFF
--- a/lib/wisper/sidekiq.rb
+++ b/lib/wisper/sidekiq.rb
@@ -6,7 +6,8 @@ require 'wisper/sidekiq/version'
 module Wisper
   class SidekiqBroadcaster
     def broadcast(subscriber, publisher, event, args)
-      subscriber.delay.public_send(event, *args)
+      method = subscriber.respond_to?(:sidekiq_delay) ? :sidekiq_delay : :delay
+      subscriber.send(method).public_send(event, *args)
     end
 
     def self.register


### PR DESCRIPTION
Hello,

Great gem, love it. Today I was having trouble with async calls to the subscriber and I noticed that the jobs are sent to sidekiq via `delay`. This is problematic if you use delayed_jobs and sidekiq in the same project. A workaround to this is to use `sidekiq_delay`, which you can turn on via `Sidekiq.hook_rails!`

https://github.com/mperham/sidekiq/wiki/Delayed-extensions#disabling-extensions

I'm not sure if there is a better way to do this (maybe there is an internal setting in Sidekiq that can be checked), but just wanted to present one way to fix it.

If you wanted to accept this version, I can also write a quick test for it.
