### PR TITLE
Added ability to customize sidekiq_options in listeners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ tmp
 *.o
 *.a
 mkmf.log
+.ruby-version
+.ruby-gemset

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'rspec'
 gem 'coveralls', require: false
 
 gem 'psych', platforms: :rbx
+gem 'rack', '~> 1.6.5'
 
 group :extras do
   gem 'rerun'

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem 'coveralls', require: false
 
 gem 'psych', platforms: :rbx
 gem 'rack', '~> 1.6.5'
+gem 'tins', '~> 1.6.0'
+gem 'term-ansicolor', '~> 1.3.2'
 
 group :extras do
   gem 'rerun'

--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,6 @@ gem 'rspec'
 gem 'coveralls', require: false
 
 gem 'psych', platforms: :rbx
-gem 'rack', '~> 1.6.5'
-gem 'tins', '~> 1.6.0'
-gem 'term-ansicolor', '~> 1.3.2'
 
 group :extras do
   gem 'rerun'

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ use its id instead.
 See the [Sidekiq best practices](https://github.com/mperham/sidekiq/wiki/Best-Practices)
 for more information.
 
+## Advanced options
+
+You can also customize queue name, retry value and other sidekiq options when registering the listener like the following:
+
+```ruby
+publisher.subscribe(MyListener, async: { queue: 'custom', retry: false })
+```
+
 ## Compatibility
 
 The same Ruby versions as Sidekiq are offically supported, but it should work
@@ -49,5 +57,5 @@ See the [build status](https://travis-ci.org/krisleech/wisper-sidekiq) for detai
 
 ## Contributing
 
-To run sidekiq use `scripts/sidekiq`. This wraps sidekiq in [rerun](https://github.com/alexch/rerun) 
+To run sidekiq use `scripts/sidekiq`. This wraps sidekiq in [rerun](https://github.com/alexch/rerun)
 which will restart sidekiq when `specs/dummy_app` changes.

--- a/lib/wisper/sidekiq.rb
+++ b/lib/wisper/sidekiq.rb
@@ -5,14 +5,20 @@ require 'wisper/sidekiq/version'
 
 module Wisper
   class SidekiqBroadcaster
+    attr_reader :options
+
+    def initialize(options = {})
+      @options = options
+    end
+
     def broadcast(subscriber, publisher, event, args)
-      subscriber.delay.public_send(event, *args)
+      subscriber.delay(options).public_send(event, *args)
     end
 
     def self.register
       Wisper.configure do |config|
-        config.broadcaster :sidekiq, SidekiqBroadcaster.new
-        config.broadcaster :async,   SidekiqBroadcaster.new
+        config.broadcaster :sidekiq, Proc.new { |options| SidekiqBroadcaster.new(options) }
+        config.broadcaster :async,   Proc.new { |options| SidekiqBroadcaster.new(options) }
       end
     end
   end

--- a/lib/wisper/sidekiq.rb
+++ b/lib/wisper/sidekiq.rb
@@ -8,7 +8,7 @@ module Wisper
     attr_reader :options
 
     def initialize(options = {})
-      @options = options
+      @options = options == true ? {} : options
     end
 
     def broadcast(subscriber, publisher, event, args)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'configuration' do
     expect(configuration.broadcasters).to include :sidekiq
   end
 
-  it 'configures sidekiq as default async broadcaster' do
-    expect(configuration.broadcasters[:async]).to be_an_instance_of(Wisper::SidekiqBroadcaster)
+  it 'configures sidekiq as default callable async broadcaster' do
+    expect(configuration.broadcasters[:async]).to be_an_instance_of(Proc)
+    expect(configuration.broadcasters[:async].call).to be_an_instance_of(Wisper::SidekiqBroadcaster)
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -20,18 +20,39 @@ RSpec.describe 'integration tests:' do
     File.delete('/tmp/shared') if File.exist?('/tmp/shared')
   end
 
-  it 'performs event in a different process' do
-    publisher.subscribe(Subscriber, async: Wisper::SidekiqBroadcaster.new)
+  context 'when broadcaster is plain object' do
+    it 'performs event in a different process' do
+      publisher.subscribe(Subscriber, async: Wisper::SidekiqBroadcaster.new)
 
-    publisher.run
+      publisher.run
 
-    Timeout.timeout(10) do
-      while !File.exist?('/tmp/shared')
-        sleep(0.1)
+      Timeout.timeout(10) do
+        while !File.exist?('/tmp/shared')
+          sleep(0.1)
+        end
       end
-    end
 
-    shared_content = File.read('/tmp/shared')
-    expect(shared_content).not_to eq "pid: #{Process.pid}\n"
+      shared_content = File.read('/tmp/shared')
+      expect(shared_content).not_to eq "pid: #{Process.pid}\n"
+    end
+  end
+
+  context 'when broadcaster is async and passes options' do
+    it 'performs event in a different process' do
+      pending('Pending until wisper support for async options is published')
+
+      publisher.subscribe(Subscriber, async: { queue: 'default' })
+
+      publisher.run
+
+      Timeout.timeout(10) do
+        while !File.exist?('/tmp/shared')
+          sleep(0.1)
+        end
+      end
+
+      shared_content = File.read('/tmp/shared')
+      expect(shared_content).not_to eq "pid: #{Process.pid}\n"
+    end
   end
 end


### PR DESCRIPTION
Hey guys,

This PR adds support of custom `sidekiq_options` when registering a listener.
In order to work it requires few changes in Wisper https://github.com/krisleech/wisper/pull/159. 

 It supports all existing configurations + adds ability to pass additional options via the following syntax:

```ruby
cancel_order.subscribe(OrderNotifier.new, async: { queue: 'custom', retry: false })
```

Decreased coverage is expected as one of the specs is suspended until `wisper` PR is merged. After `wisper` part is merged we'll need to remove this line https://github.com/krisleech/wisper-sidekiq/pull/13/files#diff-078c1c61de993e867792139abaaba7d3R42 that will enable the spec for the new syntax.

JRuby build is failing for unknown reason. I wish I could ssh to container to debug it but have no access. Locally tests work fine on this JRuby version though. Appreciate any ideas. Also @krisleech if you could restart the master branch build (it was not run for 2 years) to make sure it's failing definitely because of the changes in this PR and not because of something else.

Thanks for consideration and appreciate your thoughts.