### PR TITLE
Add the ability to schedule sidekiq jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ mkmf.log
 .ruby-version
 .ruby-gemset
 .idea
+.gs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add the ability to pass `sidekiq_schedule_options` options in order to schedule jobs to be run in the future
+
 ## [1.2.0]
 
 - fixes: gemspec does not allow sidekiq 5.x to be used

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem 'rake'
 gem 'rspec'
 gem 'coveralls', require: false
 
+gem 'redis', '<= 4.0.3' if RUBY_VERSION < '2.3'
+
 gem 'psych', platforms: :rbx
 
 group :extras do

--- a/README.md
+++ b/README.md
@@ -51,6 +51,40 @@ for more information.
 
 In order to define custom [sidekiq_options](https://github.com/mperham/sidekiq/wiki/Advanced-Options#workers) you can add `sidekiq_options` class method in your subscriber definition - those options will be passed to Sidekiq's `set` method just before scheduling the asynchronous worker.
 
+### Passing down schedule options
+
+In order be able to schedule jobs to be run in the future following [Scheduled Jobs](https://github.com/mperham/sidekiq/wiki/Scheduled-Jobs) you can add `sidekiq_schedule_options` class method in your subscriber definition - those options will be passed to Sidekiq's `perform_in` method when the worker is called.
+
+This feature is not as powerfull as Sidekiq's API that allows you to set this on every job enqueue, in this case you're able to set this for the hole listener class like:
+```ruby
+class MyListener
+  #...
+
+  def self.sidekiq_schedule_options
+    { perform_in: 5 }
+  end
+
+  #...
+end
+```
+Or you can set this per event (method called on the listener), like so:
+```ruby
+class MyListener
+  #...
+
+  def self.sidekiq_schedule_options
+    { event_name: { perform_in: 5 } }
+  end
+
+  def self.event_name
+    #...
+  end
+
+  #...
+end
+```
+In both cases there is also available the `perform_at` option.
+
 ## Compatibility
 
 The same Ruby versions as Sidekiq are offically supported, but it should work

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,1 @@
 require "bundler/gem_tasks"
-

--- a/spec/wisper/sidekiq_broadcaster_spec.rb
+++ b/spec/wisper/sidekiq_broadcaster_spec.rb
@@ -23,6 +23,60 @@ RSpec.describe Wisper::SidekiqBroadcaster do
     end
   end
 
+  class CustomizedScheduleInJobSubscriberUnderTest
+    def self.it_happened
+    end
+
+    def self.sidekiq_schedule_options
+      { perform_in: 5 }
+    end
+  end
+
+  class CustomizedEventScheduleInJobSubscriberUnderTest
+    def self.it_happened
+    end
+
+    def self.sidekiq_schedule_options
+      { it_happened: { perform_in: 5 } }
+    end
+  end
+
+  class CustomizedScheduleAtJobSubscriberUnderTest
+    def self.it_happened
+    end
+
+    def self.sidekiq_schedule_options
+      { perform_at: Time.now + 5 }
+    end
+  end
+
+  class CustomizedEventScheduleAtJobSubscriberUnderTest
+    def self.it_happened
+    end
+
+    def self.sidekiq_schedule_options
+      { it_happened: { perform_at: Time.now + 5 } }
+    end
+  end
+
+  class CustomizedBadScheduleInJobSubscriberUnderTest
+    def self.it_happened
+    end
+
+    def self.sidekiq_schedule_options
+      { perform_in: 'not a number', delay: 5 }
+    end
+  end
+
+  class CustomizedBadDefaultScheduleInWithEventScheduleAtJobSubscriberUnderTest
+    def self.it_happened
+    end
+
+    def self.sidekiq_schedule_options
+      { perform_in: 'not a number', delay: 5, it_happened: { perform_at: Time.now + 5 } }
+    end
+  end
+
   let(:publisher) { PublisherUnderTest.new }
 
   before { Sidekiq::Testing.fake! }
@@ -36,11 +90,59 @@ RSpec.describe Wisper::SidekiqBroadcaster do
         .to change(Sidekiq::Queues["default"], :size).by(1)
     end
 
+    it 'schedules to run in some time a sidekiq job' do
+      publisher.subscribe(CustomizedScheduleInJobSubscriberUnderTest, async: described_class.new)
+
+      # In order to look into Sidekiq::ScheduledSet we need to hit redis
+      expect { publisher.run }
+        .to change { Sidekiq::Queues["default"].select{|job| job.key?('at')}.size }.by(1)
+    end
+
+    it 'schedules to run in some time a sidekiq job for an event' do
+      publisher.subscribe(CustomizedEventScheduleInJobSubscriberUnderTest, async: described_class.new)
+
+      # In order to look into Sidekiq::ScheduledSet we need to hit redis
+      expect { publisher.run }
+        .to change { Sidekiq::Queues["default"].select{|job| job.key?('at')}.size }.by(1)
+    end
+
+    it 'schedules to run at some time a sidekiq job' do
+      publisher.subscribe(CustomizedEventScheduleAtJobSubscriberUnderTest, async: described_class.new)
+
+      # In order to look into Sidekiq::ScheduledSet we need to hit redis
+      expect { publisher.run }
+        .to change { Sidekiq::Queues["default"].select{|job| job.key?('at')}.size }.by(1)
+    end
+
+    it 'schedules to run at some time a sidekiq job for an event' do
+      publisher.subscribe(CustomizedEventScheduleInJobSubscriberUnderTest, async: described_class.new)
+
+      # In order to look into Sidekiq::ScheduledSet we need to hit redis
+      expect { publisher.run }
+        .to change { Sidekiq::Queues["default"].select{|job| job.key?('at')}.size }.by(1)
+    end
+
     it 'can respect custom sidekiq_options' do
       publisher.subscribe(CustomizedSubscriberUnderTest, async: described_class.new)
 
       expect { publisher.run }
         .to change(Sidekiq::Queues["my_queue"], :size).by(1)
+    end
+
+    it 'schedules a sidekiq job with bad sidekiq_schedule_options' do
+      publisher.subscribe(CustomizedBadScheduleInJobSubscriberUnderTest, async: described_class.new)
+
+      expect { publisher.run }
+        .to change(Sidekiq::Queues["default"], :size).by(1)
+      expect { publisher.run }
+        .not_to change { Sidekiq::Queues["default"].select{|job| job.key?('at')}.size }
+    end
+
+    it 'schedules a sidekiq job with bad sidekiq_schedule_options' do
+      publisher.subscribe(CustomizedBadDefaultScheduleInWithEventScheduleAtJobSubscriberUnderTest, async: described_class.new)
+
+      expect { publisher.run }
+        .to change { Sidekiq::Queues["default"].select{|job| job.key?('at')}.size }.by(1)
     end
 
     context 'when provides subscriber with args' do


### PR DESCRIPTION
Hi @krisleech huge thanks for all the work that you put into **Wisper** (and this one also)! 

I'm opening this PR in order to know WDYT about it, I know is not the best approach and is not as flexible as Sidekiq's API. But couldn't think of less intrusive way of adding the abilty to schedule jobs, do you had something in mind originally?

Also I read on this other issue #26 and #27 that you were welcoming PRs and here I'm in order to discuss it and know your thought about it.

The idea of the solution is to be able to globally schedule jobs per subscriber or per event like when you set the `sidekiq_options`, for for instance:
```ruby
class ListenerClass
  def self.sidekiq_schedule_options
    { perform_in: 5.seconds } # For set this delay on every async call
  end

  #...
end
```
and
```ruby
class ListenerClass
  def self.sidekiq_schedule_options
    { it_happened: { perform_in: 5.seconds } } # For set this delay on it_happened async calls only
  end

  def self.it_happened
    #...
  end

  #...
end
```
As I said at the beginning I know that this is not very flexible, like you're not able to set a delay at per **request**, only by listener or event. Happy to any suggestion!

Also I added an `if` on the `Worker` call in order to be more explicit, but seems that if we replace the `perform_async` for `perform_in` (`perform_at` is just an alias) with a delay of `0` everything is fine, not sure thought if I'm missing something here.

Thanks!