### PR TITLE
Allow YAML safe loading to support Ruby 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ before_script:
 services:
   - redis-server
 rvm:
-  - 2.5.7
-  - 2.6.5
+  - 2.5.9
+  - 2.6.10
+  - 2.7.7
+  - 3.0.5
+  - 3.1.2
+  - 3.2.0
   - jruby-9.2.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- **breaking change:** YAML.safe_load is used by default. Check https://github.com/krisleech/wisper-sidekiq#yaml-permitted-classes for more details
+
 ## [1.3.0] - 25/Nov/2019
 
 - Add the ability to pass `sidekiq_schedule_options` options in order to schedule jobs to be run in the future

--- a/README.md
+++ b/README.md
@@ -47,6 +47,36 @@ use its id instead.
 See the [Sidekiq best practices](https://github.com/mperham/sidekiq/wiki/Best-Practices)
 for more information.
 
+### YAML permitted classes
+
+The gem internally uses YAML serialization/deserialization to pass your event data and subscribers to a sidekiq worker through redis.
+
+By default, for security reasons, only a few basic classes like `String` or `Array` are permitted for deserialization.
+
+If you are using custom types as your event data, you might run into
+```
+Psych::DisallowedClass:
+   Tried to load unspecified class: MyEventData1
+```
+
+In that case, you can explicitly allow custom types using
+
+```ruby
+Wisper::Sidekiq.configure do |config|
+  config.register_safe_types(MyEventData1, MyEventData2)
+end
+```
+
+Alternatively, you can opt-in for unsafe YAML loading that allows the deserialization of all classes using
+
+```ruby
+Wisper::Sidekiq.configure do |config|
+  config.use_unsafe_yaml!
+end
+```
+
+Keep in mind that doing this can lead to [RCE vulneraibility](https://staaldraad.github.io/post/2019-03-02-universal-rce-ruby-yaml-load/) if an unauthorised actor gets the write access to your redis server.
+
 ### Passing down sidekiq options
 
 In order to define custom [sidekiq_options](https://github.com/mperham/sidekiq/wiki/Advanced-Options#workers) you can add `sidekiq_options` class method in your subscriber definition - those options will be passed to Sidekiq's `set` method just before scheduling the asynchronous worker.

--- a/lib/wisper/sidekiq/config.rb
+++ b/lib/wisper/sidekiq/config.rb
@@ -9,6 +9,7 @@ module Wisper
           Symbol,
           Time,
           Date,
+          DateTime,
         ].freeze
 
         def use_unsafe_yaml!

--- a/lib/wisper/sidekiq/config.rb
+++ b/lib/wisper/sidekiq/config.rb
@@ -16,6 +16,10 @@ module Wisper
           @use_unsafe_yaml = true
         end
 
+        def use_safe_yaml!
+          @use_unsafe_yaml = false
+        end
+
         def safe_types
           @safe_types ||= DEFAULT_SAFE_TYPES
         end

--- a/lib/wisper/sidekiq/config.rb
+++ b/lib/wisper/sidekiq/config.rb
@@ -8,6 +8,7 @@ module Wisper
           Class,
           Symbol,
           Time,
+          Date,
         ].freeze
 
         def use_unsafe_yaml!

--- a/lib/wisper/sidekiq/config.rb
+++ b/lib/wisper/sidekiq/config.rb
@@ -1,0 +1,36 @@
+module Wisper
+  module Sidekiq
+    class Config
+      class << self
+        attr_reader :use_unsafe_yaml
+
+        DEFAULT_SAFE_TYPES = [
+          Class,
+          Symbol,
+          Time,
+        ].freeze
+
+        def use_unsafe_yaml!
+          @use_unsafe_yaml = true
+        end
+
+        def safe_types
+          @safe_types ||= DEFAULT_SAFE_TYPES
+        end
+
+        def register_safe_types(*types)
+          @safe_types ||= DEFAULT_SAFE_TYPES
+          @safe_types += types
+          @safe_types.flatten!
+          @safe_types.uniq!
+        end
+      end
+    end
+
+    class << self
+      def configure
+        yield Config
+      end
+    end
+  end
+end

--- a/lib/wisper/sidekiq/publisher_extensions.rb
+++ b/lib/wisper/sidekiq/publisher_extensions.rb
@@ -1,7 +1,7 @@
 module Wisper
   module Sidekiq
     module PublisherExtensions
-      # Extension to automatically registered subscriber classes as safe
+      # Extension to automatically register subscriber classes as safe
       module SubscribeRegisterTypes
         def subscribe(listener, *args, **kargs, &block)
           Wisper::Sidekiq::Config.register_safe_types(listener)

--- a/lib/wisper/sidekiq/publisher_extensions.rb
+++ b/lib/wisper/sidekiq/publisher_extensions.rb
@@ -1,0 +1,28 @@
+module Wisper
+  module Sidekiq
+    module PublisherExtensions
+      # Extension to automatically registered subscriber classes as safe
+      module SubscribeRegisterTypes
+        def subscribe(listener, *args, **kargs, &block)
+          Wisper::Sidekiq::Config.register_safe_types(listener)
+          super
+        end
+      end
+    end
+  end
+
+  class << self
+    # Inject into Wisper.subscribe
+    prepend Sidekiq::PublisherExtensions::SubscribeRegisterTypes
+  end
+
+  module Publisher
+    # Inject into CustomPublisher.new.subscribe
+    prepend Sidekiq::PublisherExtensions::SubscribeRegisterTypes
+
+    module ClassMethods
+      # Inject into CustomPublisher.subscribe
+      prepend Sidekiq::PublisherExtensions::SubscribeRegisterTypes
+    end
+  end
+end

--- a/spec/dummy_app/app.rb
+++ b/spec/dummy_app/app.rb
@@ -2,7 +2,3 @@
 
 require 'wisper/sidekiq'
 require_relative 'subscriber'
-
-Wisper::Sidekiq.configure do |config|
-  config.custom_permitted_classes = [Subscriber]
-end

--- a/spec/dummy_app/app.rb
+++ b/spec/dummy_app/app.rb
@@ -2,3 +2,7 @@
 
 require 'wisper/sidekiq'
 require_relative 'subscriber'
+
+Wisper::Sidekiq.configure do |config|
+  config.custom_permitted_classes = [Subscriber]
+end

--- a/spec/wisper/sidekiq_broadcaster_spec.rb
+++ b/spec/wisper/sidekiq_broadcaster_spec.rb
@@ -151,11 +151,15 @@ RSpec.describe Wisper::SidekiqBroadcaster do
 
       subject(:broadcast_event) { described_class.new.broadcast(subscriber, nil, event, args) }
 
+      before do
+        publisher.subscribe(subscriber, async: described_class.new)
+      end
+
       context 'with basic type args' do
         let(:args) { [1,2,3] }
 
         it 'subscriber receives event with corrects args' do
-          expect(RegularSubscriberUnderTest).to receive(event).with(*args)
+          expect(subscriber).to receive(event).with(*args)
 
           Sidekiq::Testing.inline! { broadcast_event }
         end
@@ -174,7 +178,7 @@ RSpec.describe Wisper::SidekiqBroadcaster do
           end
 
           it 'subscriber receives event with corrects args' do
-            expect(RegularSubscriberUnderTest).to receive(event).with(*args)
+            expect(subscriber).to receive(event).with(*args)
 
             Sidekiq::Testing.inline! { broadcast_event }
           end
@@ -188,7 +192,7 @@ RSpec.describe Wisper::SidekiqBroadcaster do
           end
 
           it 'subscriber receives event with corrects args' do
-            expect(RegularSubscriberUnderTest).to receive(event).with(*args)
+            expect(subscriber).to receive(event).with(*args)
 
             Sidekiq::Testing.inline! { broadcast_event }
           end
@@ -196,7 +200,7 @@ RSpec.describe Wisper::SidekiqBroadcaster do
 
         context 'when the complex type is not registered as safe' do
           it 'subscriber doesn\'t receive an event and and error is raised', :aggregate_failures do
-            expect(RegularSubscriberUnderTest).not_to receive(event)
+            expect(subscriber).not_to receive(event)
 
             Sidekiq::Testing.inline! do
               expect { broadcast_event }.to raise_error(Psych::DisallowedClass)

--- a/spec/wisper/sidekiq_broadcaster_spec.rb
+++ b/spec/wisper/sidekiq_broadcaster_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe Wisper::SidekiqBroadcaster do
             Wisper::Sidekiq::Config.safe_types.replace(previous_safe_types)
           end
 
-          it 'subscriber receives event with corrects args', :aggregate_failures do
+          it 'subscriber receives event with corrects args' do
             expect(RegularSubscriberUnderTest).to receive(event).with(*args)
 
             Sidekiq::Testing.inline! { broadcast_event }
@@ -187,7 +187,7 @@ RSpec.describe Wisper::SidekiqBroadcaster do
             Wisper::Sidekiq::Config.use_safe_yaml!
           end
 
-          it 'subscriber receives event with corrects args', :aggregate_failures do
+          it 'subscriber receives event with corrects args' do
             expect(RegularSubscriberUnderTest).to receive(event).with(*args)
 
             Sidekiq::Testing.inline! { broadcast_event }
@@ -195,8 +195,8 @@ RSpec.describe Wisper::SidekiqBroadcaster do
         end
 
         context 'when the complex type is not registered as safe' do
-          it 'subscriber receives event with corrects args', :aggregate_failures do
-            expect(RegularSubscriberUnderTest).not_to receive(event).with(*args)
+          it 'subscriber doesn\'t receive an event and and error is raised', :aggregate_failures do
+            expect(RegularSubscriberUnderTest).not_to receive(event)
 
             Sidekiq::Testing.inline! do
               expect { broadcast_event }.to raise_error(Psych::DisallowedClass)


### PR DESCRIPTION
Fixes https://github.com/krisleech/wisper-sidekiq/issues/34

This is an alternative solution to https://github.com/krisleech/wisper-sidekiq/pull/35, that uses `::YAML.safe_load` by default, and requires custom types to be explicitly registered if used as event arguments. 