### PR TITLE
Use new broadcast method signature

### DIFF
--- a/wisper-sidekiq.gemspec
+++ b/wisper-sidekiq.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'wisper'
+  spec.add_dependency 'wisper', '>=3.0'
   spec.add_dependency 'sidekiq', '>=4.1'
 end


### PR DESCRIPTION
An `ArgumentError` is raised when Wisper 3.0 calls this method because is using the old signature. This fixes the issue while passing all arguments to the job's `#perform`.

This also updates the gemspec file.

Please let me know if I'm missing something.